### PR TITLE
fix disconnection when udp client port changed

### DIFF
--- a/kcp-netty/src/main/java/io/jpower/kcp/netty/Kcp.java
+++ b/kcp-netty/src/main/java/io/jpower/kcp/netty/Kcp.java
@@ -10,6 +10,7 @@ import io.jpower.kcp.netty.internal.ReItrLinkedList;
 import io.jpower.kcp.netty.internal.ReusableListIterator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectPool.Handle;
 import io.netty.util.internal.logging.InternalLogger;
@@ -184,7 +185,7 @@ public class Kcp {
 
     private int ackcount;
 
-    private Object user;
+    private Channel user;
 
     private int fastresend;
 
@@ -221,14 +222,14 @@ public class Kcp {
         return (int) (later - earlier);
     }
 
-    protected static void output(ByteBuf data, Kcp kcp) {
+    protected void output(ByteBuf data) {
         if (log.isDebugEnabled()) {
-            log.debug("{} [RO] {} bytes", kcp, data.readableBytes());
+            log.debug("{} [RO] {} bytes", this, data.readableBytes());
         }
         if (data.readableBytes() == 0) {
             return;
         }
-        kcp.output.out(data, kcp);
+        this.output.out(data, this);
     }
 
     private static int encodeSeg(ByteBuf buf, Segment seg) {
@@ -341,7 +342,7 @@ public class Kcp {
         if (buffer == null) {
             buffer = createFlushByteBuf();
         } else if (buffer.readableBytes() + need > mtu) {
-            output(buffer, this);
+            output(buffer);
             buffer = createFlushByteBuf();
         }
         return buffer;
@@ -1061,7 +1062,7 @@ public class Kcp {
         // flash remain segments
         if (buffer != null) {
             if (buffer.readableBytes() > 0) {
-                output(buffer, this);
+                output(buffer);
             } else {
                 buffer.release();
             }
@@ -1298,11 +1299,11 @@ public class Kcp {
     	this.conv = secureRandom.nextLong();
     }
 
-    public Object getUser() {
+    public Channel getUser() {
         return user;
     }
 
-    public void setUser(Object user) {
+    public void setUser(Channel user) {
         this.user = user;
     }
 

--- a/kcp-netty/src/main/java/io/jpower/kcp/netty/Ukcp.java
+++ b/kcp-netty/src/main/java/io/jpower/kcp/netty/Ukcp.java
@@ -83,23 +83,21 @@ public class Ukcp {
 
     	switch (code) {
 	    	case 255: // Connect + Handshake
-                System.out.println("Send Connect + Handshake");
                 this.sendHandshakeRsp(enet);
 	    		break;
 	    	case 404: // Disconnect
-                System.out.println("Send Disconnect");
 	    		sendDisconnectPacket(this.getConv(), 1);
 	        	this.channel().close();
 	    		break;
             default:
-                data.resetReaderIndex();
-                System.out.println("Unknown handle pack["+code+"]:"+ByteBufUtil.prettyHexDump(data));
+                ///data.resetReaderIndex();
+                //System.out.println("Unknown handle pack["+code+"]:"+ByteBufUtil.prettyHexDump(data));
                 break;
     	}
     }
     
     private void sendHandshakeRsp(int enet) {
-        System.out.println("sendHandshakeRsp!!!!!");
+        //System.out.println("sendHandshakeRsp!!!!!");
     	// Create conv
     	this.kcp.generateConv();
     	
@@ -144,8 +142,8 @@ public class Ukcp {
             	this.sendDisconnectPacket(data.getLong(0), 5);
                 throw new IOException("Mismatch cmd");
             case -4:
-                data.resetReaderIndex();
-                System.out.println("Conv inconsistency["+kcp.getConv()+"]:"+ByteBufUtil.prettyHexDump(data));
+                //data.resetReaderIndex();
+                //System.out.println("Conv inconsistency["+kcp.getConv()+"]:"+ByteBufUtil.prettyHexDump(data));
             	this.sendDisconnectPacket(data.getLong(0), 5);
                 throw new IOException("Conv inconsistency");
             default:

--- a/kcp-netty/src/main/java/io/jpower/kcp/netty/UkcpServerChannel.java
+++ b/kcp-netty/src/main/java/io/jpower/kcp/netty/UkcpServerChannel.java
@@ -681,7 +681,7 @@ public final class UkcpServerChannel extends AbstractNioMessageChannel implement
             NioUnsafe unsafe = unsafe();
             unsafe.write(UkcpPacket.newInstance(data,address), unsafe.voidPromise());
             unsafe.flush();
-            System.out.println("socketAddress send:"+address);
+            //System.out.println("socketAddress send:"+address);
         }
 
     }

--- a/kcp-netty/src/main/java/io/jpower/kcp/netty/UkcpServerChildChannel.java
+++ b/kcp-netty/src/main/java/io/jpower/kcp/netty/UkcpServerChildChannel.java
@@ -43,7 +43,7 @@ public final class UkcpServerChildChannel extends AbstractChannel implements Ukc
         this.ukcp = ukcp;
     }
     public void setSocketAddress(InetSocketAddress socketAddress){
-        System.out.println("socketAddress update:"+socketAddress.toString());
+        //System.out.println("socketAddress update:"+socketAddress.toString());
         this.socketAddress=socketAddress;
     }
     public InetSocketAddress getSocketAddress(){
@@ -96,7 +96,7 @@ public final class UkcpServerChildChannel extends AbstractChannel implements Ukc
 
     @Override
     protected SocketAddress remoteAddress0() {
-        System.out.println("remoteAddress0 CALLED! socketAddress="+socketAddress);
+        //System.out.println("remoteAddress0 CALLED! socketAddress="+socketAddress);
         return getSocketAddress();
     }
 

--- a/kcp-netty/src/main/java/io/jpower/kcp/netty/UkcpServerChildChannel.java
+++ b/kcp-netty/src/main/java/io/jpower/kcp/netty/UkcpServerChildChannel.java
@@ -32,19 +32,23 @@ public final class UkcpServerChildChannel extends AbstractChannel implements Ukc
     private final DefaultUkcpServerChildChannelConfig config;
 
     private final Ukcp ukcp;
-
-    private final InetSocketAddress remoteAddress;
+    private InetSocketAddress socketAddress=null;
 
     private boolean flushPending;
 
-    UkcpServerChildChannel(Channel parent, Ukcp ukcp, InetSocketAddress remoteAddress) {
+    UkcpServerChildChannel(Channel parent, Ukcp ukcp) {
         super(parent);
         this.config = new DefaultUkcpServerChildChannelConfig(this, ukcp);
         ukcp.channel(this);
         this.ukcp = ukcp;
-        this.remoteAddress = remoteAddress;
     }
-
+    public void setSocketAddress(InetSocketAddress socketAddress){
+        System.out.println("socketAddress update:"+socketAddress.toString());
+        this.socketAddress=socketAddress;
+    }
+    public InetSocketAddress getSocketAddress(){
+        return socketAddress;
+    }
     @Override
     public UkcpServerChannel parent() {
         return (UkcpServerChannel) super.parent();
@@ -92,8 +96,10 @@ public final class UkcpServerChildChannel extends AbstractChannel implements Ukc
 
     @Override
     protected SocketAddress remoteAddress0() {
-        return remoteAddress;
+        System.out.println("remoteAddress0 CALLED! socketAddress="+socketAddress);
+        return getSocketAddress();
     }
+
 
     @Override
     protected void doBind(SocketAddress localAddress) throws Exception {


### PR DESCRIPTION
The KCP library uses InetSocketAddress rather than a CONV id as a unique session id,so InetSocketAddress port may changes in playing game when network weak , it will cause Server can't recognize InetSocketAddress new port is same player